### PR TITLE
Update library.json for PIO compatibility

### DIFF
--- a/library.json
+++ b/library.json
@@ -14,5 +14,6 @@
 {
     "type": "git",
     "url": "https://github.com/PaulStoffregen/FreqCount"
-}
+},
+"include":"FreqCount/*"
 }


### PR DESCRIPTION
Fix issue #9 
Add child directory to manifest so PIO dependency checker will find it correctly if download_url is prjc.com.