### PR TITLE
Correction Move T4 delta/count_prev to callback and Add Missing End Function

### DIFF
--- a/FreqCount.cpp
+++ b/FreqCount.cpp
@@ -126,8 +126,8 @@ uint8_t FreqCountClass::available(void)
 
 uint32_t FreqCountClass::read(void)
 {
-    count_ready = 0;
-	count = 0;
+  count_ready = 0;
+  count = 0;
   
   return count_output;
 }

--- a/FreqCount.cpp
+++ b/FreqCount.cpp
@@ -126,11 +126,8 @@ uint8_t FreqCountClass::available(void)
 
 uint32_t FreqCountClass::read(void)
 {
-    count_output = count - count_prev;
-    count_prev = count;
-    //Serial.println(count - count_prev);
-    count_prev = count;
     count_ready = 0;
+	count = 0;
   
   return count_output;
 }

--- a/FreqCount.cpp
+++ b/FreqCount.cpp
@@ -127,8 +127,6 @@ uint8_t FreqCountClass::available(void)
 uint32_t FreqCountClass::read(void)
 {
   count_ready = 0;
-  count = 0;
-  
   return count_output;
 }
 

--- a/FreqCount.cpp
+++ b/FreqCount.cpp
@@ -135,6 +135,11 @@ uint32_t FreqCountClass::read(void)
   return count_output;
 }
 
+void FreqCountClass::end(void)
+{
+	timer_shutdown();
+}
+
 #endif
 
 FreqCountClass FreqCount;

--- a/util/FreqCountTimers.h
+++ b/util/FreqCountTimers.h
@@ -380,6 +380,7 @@ static inline void timer_start(void)
 
 static inline void timer_shutdown(void)
 {
+	itimer.end();
 }
 
 

--- a/util/FreqCountTimers.h
+++ b/util/FreqCountTimers.h
@@ -364,6 +364,8 @@ volatile uint32_t count;
 static void timer_callback()
 {
   count = TMRx->CH[2].CNTR | TMRx->CH[3].HOLD << 16; // atomic
+  count_output = count - count_prev;
+  count_prev = count;
   count_ready = 1;
 }
 


### PR DESCRIPTION
This adds in the missing FreqCount.end() function identified in https://forum.pjrc.com/threads/58014-Teensy-4-FreqCount-compile-error