### PR TITLE
Add define for ATmega328PB

### DIFF
--- a/util/FreqCountTimers.h
+++ b/util/FreqCountTimers.h
@@ -71,6 +71,10 @@ static volatile uint32_t usec;
   #define COUNTER_USE_TIMER1    // T1 is pin 5
   #define TIMER_USE_TIMER2
 
+#elif defined(__AVR_ATmega328PB__)
+  #define COUNTER_USE_TIMER1    // T1 is pin 5
+  #define TIMER_USE_TIMER2
+
 #else
   #error "Unknown chip, please edit me with timer+counter definitions"
 


### PR DESCRIPTION
I noticed I was getting an error compiling specifically for the 328PB so I added the necessary define. I added it as a separate block as the 328PB has two extra timers/counters not found on the 328P; T3 & T4. I've no idea if they're suitable for use with your library and a case of just defining `COUNTER_USE_TIMER3`, etc.

I'm only using T1 currently so I think I can get away with compiling for 328P for now.